### PR TITLE
Correct state transitions

### DIFF
--- a/custom_components/moebot/manifest.json
+++ b/custom_components/moebot/manifest.json
@@ -6,7 +6,7 @@
   "issue_tracker": "https://github.com/Whytey/moebot-hass-integration/issues",
   "config_flow": true,
   "requirements": [
-    "pymoebot==0.2.3",
+    "pymoebot==0.3.1",
     "graphviz==0.20.3",
     "pydot==2.0.0",
     "transitions==0.9.1",

--- a/custom_components/moebot/manifest.json
+++ b/custom_components/moebot/manifest.json
@@ -2,11 +2,15 @@
   "domain": "moebot",
   "name": "MoeBot",
   "documentation": "https://github.com/Whytey/moebot-hass-integration",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "issue_tracker": "https://github.com/Whytey/moebot-hass-integration/issues",
   "config_flow": true,
   "requirements": [
-    "pymoebot==0.2.3"
+    "pymoebot==0.2.3",
+    "graphviz==0.20.3",
+    "pydot==2.0.0",
+    "transitions==0.9.1",
+    "networkx==3.3"
   ],
   "ssdp": [],
   "zeroconf": [],

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,5 @@
 homeassistant>=2023.9
+graphviz==0.20.3
+pydot==2.0.0
+transitions==0.9.1
+networkx==3.3


### PR DESCRIPTION
This adds the ability to press any command button the UI and have the appropriate sequence of commands issued to the mower.

For example, if the mower is mowing and you request it return to the dock, this changes causes the mower to automatically be commanded to pause, then cancel the mowing job in progress and then issue a command to go park.