### PR TITLE
Provide the ability to reconfigure the MoeBot device. Also fix issue … 

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,6 @@ Feel free to continue to log any issues you have an if possible, I may try and a
 
 The following are a list of features I would like to have added if I continued with the MoeBot:
 
-- Ability to reconfigure the settings using `ConfigFlow`.
 - Improve the current `ConfigFlow` for adding a MoeBot device; maybe attempt discovery or at least use the abilities of `tinytuya` to identify the Local Key. 
 - Provide additional sensors to show Tx/Rx message counts to the mower, including error counters (this would require an accompanying update to the pymoebot library).
 - Investigate the benefit of moving to a single coordinator for this integration, per the newer integration development guides.

--- a/custom_components/moebot/const.py
+++ b/custom_components/moebot/const.py
@@ -1,3 +1,7 @@
 """Constants for the MoeBot integration."""
 
 DOMAIN = "moebot"
+
+DEVICE_ID = "device_id"
+IP_ADDRESS = "ip_address"
+LOCAL_KEY = "local_key"

--- a/custom_components/moebot/manifest.json
+++ b/custom_components/moebot/manifest.json
@@ -2,7 +2,7 @@
   "domain": "moebot",
   "name": "MoeBot",
   "documentation": "https://github.com/Whytey/moebot-hass-integration",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "issue_tracker": "https://github.com/Whytey/moebot-hass-integration/issues",
   "config_flow": true,
   "requirements": [


### PR DESCRIPTION
…introduced with 2024.7 where you cannot have a blocking call to time.sleep, as identified in https://github.com/Whytey/moebot-hass-integration/issues/36.